### PR TITLE
Add missing API for handling payment notifications

### DIFF
--- a/src/Model/Request/OrderNotifyRequest.php
+++ b/src/Model/Request/OrderNotifyRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace DigitalVirgo\DirectPay\Model\Request;
+use DigitalVirgo\DirectPay\Model\Order;
+
+/**
+ * Class OrderNotifyRequest
+ * @package DigitalVirgo\DirectPay\Model\Request
+ *
+ */
+class OrderNotifyRequest extends RequestAbstract
+{
+
+    /**
+     * @var Order
+     */
+    protected $_order;
+
+    /**
+     * @return Order
+     */
+    public function getOrder()
+    {
+        return $this->_order;
+    }
+
+    /**
+     * @param Order $order
+     * @return OrderNotifyResponse
+     */
+    public function setOrder($order)
+    {
+        if (is_array($order)) {
+            $order = new Order($order);
+        }
+
+        $this->_order = $order;
+        return $this;
+    }
+
+    /**
+     * @return array xml DOM map
+     */
+    protected function _getDomMap()
+    {
+        $parentMap = parent::_getDomMap()[0];
+
+        return [
+            'OrderNotifyRequest' => array_merge($parentMap, [
+                'Order' => 'order',
+            ]),
+        ];
+    }
+}

--- a/src/Model/Response/OrderNotifyResponse.php
+++ b/src/Model/Response/OrderNotifyResponse.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace DigitalVirgo\DirectPay\Model\Response;
+
+/**
+ * Class OrderNotifyResponse
+ * @package DigitalVirgo\DirectPay\Model\Response
+ *
+ */
+class OrderNotifyResponse extends ResponseAbstract
+{
+    /**
+     * @return array xml DOM map
+     */
+    protected function _getDomMap()
+    {
+        $parentMap = parent::_getDomMap()[0];
+
+        return [
+            'OrderNotifyResponse' => []
+        ];
+    }
+}

--- a/src/Service/Client.php
+++ b/src/Service/Client.php
@@ -239,4 +239,23 @@ class Client extends GuzzleClient
         return $responseObj->fromXml($response);
     }
 
+    /**
+     * Parse incoming data from payment notify callback.
+
+     * @return Response\OrderNotifyResponse response
+     * @throws \Exception
+     */
+    public function notifyParseRequest() {
+        $postData = file_get_contents("php://input");
+        $requestObj = new Request\OrderNotifyRequest();
+        return $requestObj->fromXml($postData);
+    }
+
+    /**
+     * Send OK response for payment notify callback and exit.
+     */
+    public function notifySendOkAndExit() {
+        $responseObj = new Response\OrderNotifyResponse();
+        die($responseObj->toXML());
+    }
 }


### PR DESCRIPTION
Example usage with laravel:

```
    public function justpayNotify() {
        $restApiUrl = 'https://directpay-partner.services.avantis.pl/';

        $client = Client::getInstance($restApiUrl);
        $notify = $client->notifyParseRequest();
        $order = $notify->order;
      // handle $order object

        $client->notifySendOkAndExit();
        die();
    }
```